### PR TITLE
Add comparison operators to --filter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ These input selection options can be used with each `tbl` subcommand:
 | Cast to a new type | `tbl --cast col1=u64 col2=String` |
 | Add new columns | `tbl --with-columns name:String date:Date=2024-01-01` |
 | Drop columns | `tbl --drop col1 col2 col3` |
-| Filter rows | `tbl --filter col1=val1` |
+| Filter rows | `tbl --filter col1=val1` <br> `tbl --filter col1!=val1` <br> `tbl --filter "col1>val1"` <br> `tbl --filter "col1<val1"`<br> `tbl --filter "col1>=val1"` <br> `tbl --filter "col1<=val1"` |
 | Sort rows | `tbl --sort col1 col2:desc` |
 | Select columns | `tbl --select col1 col2 col3` |
 

--- a/crates/tbl-cli/src/transform.rs
+++ b/crates/tbl-cli/src/transform.rs
@@ -260,7 +260,7 @@ fn apply_comparison_filter(
                 return Err(TblCliError::Error(format!("Invalid filter operator: {}", operator)));
             }
         }
-        DataType::UInt64 | DataType::Int64 => {
+        DataType::UInt64 | DataType::Int64 | DataType::UInt32 | DataType::Int32 => {
             let int_value = if let Some(hex_value) = value.strip_prefix("0x") {
                 i64::from_str_radix(hex_value, 16)
                     .map_err(|e| TblCliError::Error(format!("Invalid hex integer: {}", e)))?

--- a/crates/tbl-cli/src/transform.rs
+++ b/crates/tbl-cli/src/transform.rs
@@ -159,11 +159,25 @@ fn apply_single_filter(
     filter: &str,
     schema: &Schema,
 ) -> Result<LazyFrame, TblCliError> {
-    if filter.contains('=') {
-        apply_equality_filter(lf, filter, schema, true)
-    } else if filter.contains("!=") {
-        apply_equality_filter(lf, filter, schema, false)
-    } else if filter.ends_with(".is_null") {
+    if filter.contains("!=") {
+        apply_comparison_filter(lf, filter, schema, "!=")
+    }
+    else if filter.contains(">=") {
+        apply_comparison_filter(lf, filter, schema, ">=")
+    }
+    else if filter.contains("<=") {
+        apply_comparison_filter(lf, filter, schema, "<=")
+    }
+    else if filter.contains('=') {
+        apply_comparison_filter(lf, filter, schema, "=")
+    } 
+    else if filter.contains(">") {
+        apply_comparison_filter(lf, filter, schema, ">")
+    }
+    else if filter.contains("<") {
+        apply_comparison_filter(lf, filter, schema, "<")
+    }
+    else if filter.ends_with(".is_null") {
         apply_null_filter(lf, filter, schema, true)
     } else if filter.ends_with(".is_not_null") {
         apply_null_filter(lf, filter, schema, false)
@@ -172,16 +186,26 @@ fn apply_single_filter(
     }
 }
 
-fn apply_equality_filter(
+fn apply_comparison_filter(
     lf: LazyFrame,
     filter: &str,
     schema: &Schema,
-    is_equality: bool,
+    operator: &str,
 ) -> Result<LazyFrame, TblCliError> {
-    let parts: Vec<&str> = if is_equality {
+    let parts: Vec<&str> = if operator == "=" {
         filter.split('=').collect()
-    } else {
+    } else if operator == "!=" {
         filter.split("!=").collect()
+    } else if operator == ">" {
+        filter.split('>').collect()
+    } else if operator == "<" {
+        filter.split('<').collect()
+    } else if operator == ">=" {
+        filter.split(">=").collect()
+    } else if operator == "<=" {
+        filter.split("<=").collect()
+    } else {
+        return Err(TblCliError::Error(format!("Invalid filter operator: {}", operator)));
     };
 
     if parts.len() != 2 {
@@ -198,10 +222,20 @@ fn apply_equality_filter(
             if let Some(hex_value) = value.strip_prefix("0x") {
                 let binary_value = hex::decode(hex_value)
                     .map_err(|e| TblCliError::Error(format!("Invalid hex value: {}", e)))?;
-                if is_equality {
+                if operator == "=" {
                     col(column).eq(lit(binary_value))
-                } else {
+                } else if operator == "!=" {
                     col(column).neq(lit(binary_value))
+                } else if operator == ">" {
+                    col(column).gt(lit(binary_value))
+                } else if operator == "<" {
+                    col(column).lt(lit(binary_value))
+                } else if operator == ">=" {
+                    col(column).gt_eq(lit(binary_value))
+                } else if operator == "<=" {
+                    col(column).lt_eq(lit(binary_value))
+                } else {
+                    return Err(TblCliError::Error(format!("Invalid filter operator: {}", operator)));
                 }
             } else {
                 return Err(TblCliError::Error(
@@ -210,10 +244,20 @@ fn apply_equality_filter(
             }
         }
         DataType::String => {
-            if is_equality {
+            if operator == "=" {
                 col(column).eq(lit(value))
-            } else {
+            } else if operator == "!=" {
                 col(column).neq(lit(value))
+            } else if operator == ">" {
+                col(column).gt(lit(value))
+            } else if operator == "<" {
+                col(column).lt(lit(value))
+            } else if operator == ">=" {
+                col(column).gt_eq(lit(value))
+            } else if operator == "<=" {
+                col(column).lt_eq(lit(value))
+            } else {
+                return Err(TblCliError::Error(format!("Invalid filter operator: {}", operator)));
             }
         }
         DataType::UInt64 | DataType::Int64 => {
@@ -225,10 +269,20 @@ fn apply_equality_filter(
                     .parse::<i64>()
                     .map_err(|e| TblCliError::Error(format!("Invalid integer: {}", e)))?
             };
-            if is_equality {
+            if operator == "=" {
                 col(column).eq(lit(int_value))
-            } else {
+            } else if operator == "!=" {
                 col(column).neq(lit(int_value))
+            } else if operator == ">" {
+                col(column).gt(lit(int_value))
+            } else if operator == "<" {
+                col(column).lt(lit(int_value))
+            } else if operator == ">=" {
+                col(column).gt_eq(lit(int_value))
+            } else if operator == "<=" {
+                col(column).lt_eq(lit(int_value))
+            } else {
+                return Err(TblCliError::Error(format!("Invalid filter operator: {}", operator)));
             }
         }
         _ => {


### PR DESCRIPTION
- Adds the `<=`, `>=`, `>`, `<` comparision operators and fixes `!=` for the `--filter` option.
- Fixes the usage of `--filter` on columns that are of type `u32` such as the `block_number` column generated from a cryo parquet file.
- Updates docs.

Tested with parquet files outputted by `cryo` :)

**Note:** To use the  `<=`, `>=`, `>`, `<` operators, you must wrap the value in quotations. 
For example, `--filter "block_number>=20522753"`. This is because `>` and `<` are special characters in the terminal. Without the quotations, `args.filter` in `apply_transformations()` would only receive `block_number` instead of `block_number>=20522753`.